### PR TITLE
Remove API key from train script

### DIFF
--- a/BeamRL/train.py
+++ b/BeamRL/train.py
@@ -121,7 +121,7 @@ def train(config: dict) -> None:
     run_name = f"{run_mode}_{config.get('project', 'clapa')}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     
     if os.environ.get("WANDB_MODE") != "disabled":
-        wandb.login(key="4d8a8w4das5d46as5")
+        wandb.login(key=os.environ.get("WANDB_API_KEY"))
     
     wandb.init(
         project="clapa",                        

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# BeamRL
+
+This repository contains reinforcement learning tools for beam tuning.
+
+## Environment Variables
+
+The training script expects your WandB API key to be provided via the `WANDB_API_KEY` environment variable. Set this variable before running `train.py` if you wish to use WandB online logging.


### PR DESCRIPTION
## Summary
- use `WANDB_API_KEY` env var for `wandb.login`
- document `WANDB_API_KEY` in new README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff69c2020832b907e86d425fea006